### PR TITLE
add - new light adding interface, allowing up to max four lights

### DIFF
--- a/config/config_base.py
+++ b/config/config_base.py
@@ -1,5 +1,8 @@
 import os
 
+DEBUG = True
+USE_LIGHT_FIXTURES = False
+
 # logging levels: 10 = debug, 20 = info, 30 = warning, 40 = error
 LOG_LEVEL = 10
 LOG_FILENAME = "alterspace.log"

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -5,3 +5,4 @@ VUE_APP_DEBUG=true
 VUE_APP_SOUND_LOCAL_URL=http://localhost:5000/sounds/
 VUE_APP_SOUND_REMOTE_URL=http://library.law.harvard.edu/projects/files/sounds/
 VUE_APP_SOUND_LOCATION=REMOTE
+VUE_APP_MAX_LIGHTS=4

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -5,3 +5,4 @@ VUE_APP_DEBUG=false
 VUE_APP_SOUND_LOCAL_URL=http://localhost:5000/sounds/
 VUE_APP_SOUND_REMOTE_URL=http://library.law.harvard.edu/projects/files/sounds/
 VUE_APP_SOUND_LOCATION=REMOTE
+VUE_APP_MAX_LIGHTS=4

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -57,8 +57,8 @@
       }
     },
     mounted() {
-      this.light = localStorage.getItem("light");
-      if (!(this.light)) {
+      this.lights = localStorage.getItem("lights");
+      if (!(this.lights)) {
         this.$router.replace('/light');
       }
     }

--- a/frontend/src/assets/css/base.scss
+++ b/frontend/src/assets/css/base.scss
@@ -621,6 +621,7 @@ button, .btn, .btn-default {
   background-color: $color-blue;
   color: $color-white;
   font-weight: $font-weight-bold;
+  padding: 30px;
   &:hover, &:focus, &:active {
     background-color: $color-read;
   }

--- a/frontend/src/components/Lights.vue
+++ b/frontend/src/components/Lights.vue
@@ -1,46 +1,114 @@
 <template>
   <div class="col-centered col-6">
-    <div class="col-12 alert-warning">{{error}}</div>
+    <h4> Choose lights</h4>
+    <div class="description">
+      Enter a label like "Table Lamp" and a MAC address like "12:45:56:99:9a:bc"
+    </div>
+    <div class="col-12 alert-danger">{{error1}}</div>
+    <div class="col-12 alert-danger">{{error2}}</div>
     <br/>
-    <ul class="btn-group list-inline">
-      <li v-for="val in lights" class="list-inline-item" v-bind:key="val">
-      <button class="btn btn-default btn-light-choice" @click="setLight(val)">
-        {{val}}
-      </button>
-      </li>
-    </ul>
+
+    <table class="col-12">
+      <tr v-for="val in maxLights" class="list-inline-item" v-bind:key="val">
+        <td>
+          <label>Label #{{val}}: </label><input/>
+        </td>
+        <td>
+          <label>Mac address: </label><input/>
+        </td>
+      </tr>
+    </table>
+    <input type="submit" @click="setLights()" value="Submit">
+    <div class="col-12 alert-success">{{successMessage}}</div>
   </div>
 </template>
 
 <script>
+  import axios from "axios";
+
+  const storeLightsUrl = process.env.VUE_APP_BACKEND_URL + "lights/create";
+  const getLightsUrl = process.env.VUE_APP_BACKEND_URL + "lights";
+  const maxLights = process.env.VUE_APP_MAX_LIGHTS;
   export default {
     name: "Lights",
     data() {
       return {
-        lights: ["1", "2", "3"],
-        light: "",
-        error: ""
+        maxLights: Number(maxLights),
+        lights: [],
+        error1: "",
+        error2: "",
+        successMessage: "",
       }
     },
     methods: {
-      setLight(val) {
-        this.light = val;
-        localStorage.setItem('light', this.light);
-        this.$router.replace('/');
-      }
 
+      getLights() {
+        let self = this;
+        let inputs = this.$el.querySelectorAll("td");
+        let localStorageLights = [];
+        axios.get(getLightsUrl)
+            .then((res) => {
+              let lightNum = 0;
+              for (let i = 0; i < res.data.length * 2; i++) {
+                if (i % 2 === 0) {
+                  lightNum = i / 2;
+                  inputs[i].getElementsByTagName('input')[0].value = res.data[lightNum][0];
+                } else {
+                  inputs[i].getElementsByTagName('input')[0].value = res.data[lightNum][1];
+                  localStorageLights.push([res.data[lightNum][0], res.data[lightNum][1]])
+                }
+              }
+              localStorage.setItem("lights", JSON.stringify(localStorageLights));
+            })
+
+      },
+      setLights() {
+        let allLights = this.$el.querySelectorAll("td");
+        let key = "";
+        let val = "";
+        let light = [];
+        this.error1 = "";
+        this.error2 = "";
+        for (let i = 0; i < allLights.length; i++) {
+          if (i % 2 === 0) {
+            light = [];
+            key = allLights[i].getElementsByTagName('input')[0].value;
+            light.push(key)
+          } else {
+            val = allLights[i].getElementsByTagName('input')[0].value;
+            if (val.length && key.length) {
+              light.push(val);
+              this.lights.push(light);
+            } else if (val.length && !(key.length)) {
+              this.error1 = "All lights need a label";
+              return
+            }
+            if (!(val.length) && key.length) {
+              this.error2 = "Please enter the MAC address for each light."
+              return
+            }
+          }
+        }
+
+        let bodyFormData = new FormData();
+        bodyFormData.set('lights', JSON.stringify(this.lights));
+        let self = this;
+
+        if (self.lights.length > 0) {
+          axios({
+            method: "post",
+            url: storeLightsUrl,
+            data: bodyFormData
+          }).then(() => {
+            localStorage.setItem("lights", self.lights);
+            self.successMessage = "Success! " + self.lights.length + " light(s) created.";
+          });
+        }
+      },
     },
 
     mounted() {
-      if (this.$route.params.id) {
-        localStorage.setItem('light', this.$route.params.id);
-        this.light = this.$route.params.id;
-      } else {
-        this.light = localStorage.getItem('light');
-        if (!(this.light)) {
-          this.error = "Light is not set. Please set light first by clicking one of the options below."
-        }
-      }
+      this.getLights();
     }
   }
 </script>

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,25 @@
+import pytest
+from lifxlan import LifxLAN, MultiZoneLight
+
+
+def lifx_lights():
+    lights = [
+        {
+            "mac_addr": "12:34:56:78:9a:bc",
+            "ip_addr": "192.168.0.2"
+        },
+        {
+            "mac_addr": "12:45:56:99:9a:bc",
+            "ip_addr": "192.168.0.3"
+        }
+    ]
+    multizonelights = []
+    for light in lights:
+        multizonelights.append(MultiZoneLight(light["mac_addr"], light["ip_addr"]))
+
+    return multizonelights
+
+
+@pytest.fixture(scope='function')
+def get_lights():
+    return lifx_lights()


### PR DESCRIPTION
unchanged:
- storing lights in both files in the lightstore dir
- also putting them in localstorage so that frontend has easy access

changed:
- allowing up to four lights
- storing lights in lightstore dir by their labels
- localstorage now takes in key "lights" and returns a stringified array of arrays: 
```javascript
localStorage.getItem("lights")
$ "[[\"Standing light\",\"12:34:56:78:9a:bc\"],[\"table lamp\",\"12:45:56:99:9a:bc\"]]"
```
- no longer clearing and re-creating lights on each server restart
- if config variable `USE_LIGHT_FIXTURES` is used, create fake instances of lifxlan lights, allows working without any lights attached
